### PR TITLE
Initialize Next.js web app

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# production
+/.next
+/out
+
+# misc
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.env*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# food-allergen
-allergen tracker app
+# Food Allergen
+
+This project contains a simple Next.js web application for tracking food allergens.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The app will be available at <http://localhost:3000>.
+
+## Building
+
+Create an optimized production build:
+
+```bash
+npm run build
+```

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,14 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Food Allergen Tracker',
+  description: 'Track allergens in foods',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Food Allergen Tracker</h1>
+      <p>Welcome to the Food Allergen tracker built with Next.js.</p>
+    </main>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "food-allergen",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add Next.js project scaffold with basic layout and page
- configure linting and Next.js settings

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: next: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22261101c832c8752cd6ccfec5f53